### PR TITLE
encapsulate notification into try/catch

### DIFF
--- a/gSpeech.py
+++ b/gSpeech.py
@@ -353,10 +353,16 @@ class MainApp:
             text = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD).wait_for_text()
 
         if text == None :
-            Notify.Notification.new(APPNAME, _(u"No text selected."), self.icon).show()
+            try:
+                Notify.Notification.new(APPNAME, _(u"No text selected."), self.icon).show()
+            except:
+                pass
 
         else :
-            Notify.Notification.new(APPNAME, _(u"I'm reading the text. One moment please."), self.icon).show()
+            try:
+                Notify.Notification.new(APPNAME, _(u"I'm reading the text. One moment please."), self.icon).show()
+            except:
+                pass
 
             #~ text = text.lower()
             text = text.replace('\"', '')


### PR DESCRIPTION
I tried to launch gSpeech in raspbian but without **xfce4-notifyd** package, gSeech was blocked on: 

```
Traceback (most recent call last):
  File "./gSpeech.py", line 356, in onExecute
    pynotify.Notification(APPNAME, _(u"No text selected."), self.icon).show()
glib.GError: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.Notifications was not provided by any .service files
```

I think, notification must not been bloking anyway.